### PR TITLE
Implemented TileTags to define tiles that should only generate at path start or end 

### DIFF
--- a/Assets/PTD/Resources/Tiles/TileH2P_End.asset
+++ b/Assets/PTD/Resources/Tiles/TileH2P_End.asset
@@ -19,5 +19,6 @@ MonoBehaviour:
   eastSockets: 010000000200000003000000
   southSockets: 010000000200000003000000
   westSockets: 010000000200000003000000
+  optionalTileTag: 2
   addToAllSides: 
   removeFromAllSides: 

--- a/Assets/PTD/Resources/Tiles/TileH2P_Start.asset
+++ b/Assets/PTD/Resources/Tiles/TileH2P_Start.asset
@@ -19,5 +19,6 @@ MonoBehaviour:
   eastSockets: 010000000200000003000000
   southSockets: 010000000200000003000000
   westSockets: 010000000200000003000000
+  optionalTileTag: 1
   addToAllSides: 
   removeFromAllSides: 

--- a/Assets/PTD/Resources/Tiles/TileH3P_End.asset
+++ b/Assets/PTD/Resources/Tiles/TileH3P_End.asset
@@ -19,5 +19,6 @@ MonoBehaviour:
   eastSockets: 030000000400000005000000
   southSockets: 030000000400000005000000
   westSockets: 030000000400000005000000
+  optionalTileTag: 2
   addToAllSides: 
   removeFromAllSides: 

--- a/Assets/PTD/Resources/Tiles/TileH3P_Start.asset
+++ b/Assets/PTD/Resources/Tiles/TileH3P_Start.asset
@@ -19,5 +19,6 @@ MonoBehaviour:
   eastSockets: 030000000400000005000000
   southSockets: 030000000400000005000000
   westSockets: 030000000400000005000000
+  optionalTileTag: 1
   addToAllSides: 
   removeFromAllSides: 

--- a/Assets/PTD/Scripts/Path Generation/PathGenerator.cs
+++ b/Assets/PTD/Scripts/Path Generation/PathGenerator.cs
@@ -124,6 +124,8 @@ public class PathGenerator : MonoBehaviour
 
         UpdateAllNodesBasedOnPathValue();
 
+        OverwritePotentialTilesOfStartAndEndNodes();
+
         UpdateNodesInPathBasedOnPathDirection();
 
         OnPathGenerated.Invoke();
@@ -137,6 +139,12 @@ public class PathGenerator : MonoBehaviour
             Node node = keyValuePair.Value;
             node.ReducePotentialTilesByPathFlag();
         }
+    }
+
+    private void OverwritePotentialTilesOfStartAndEndNodes()
+    {
+        path[0].potentialTiles = NodeManager.startTiles;
+        path[path.Count - 1].potentialTiles = NodeManager.endTiles;
     }
 
     private void UpdateNodesInPathBasedOnPathDirection()

--- a/Assets/PTD/Scripts/WaveFunctionCollapse/NodeManager.cs
+++ b/Assets/PTD/Scripts/WaveFunctionCollapse/NodeManager.cs
@@ -15,6 +15,8 @@ public class NodeManager : MonoBehaviour
     public static NodeManager instance { get; set; }
     public Dictionary<Vector2Int, Node> nodeGrid { get; private set; }
     private static List<Tile> allTiles; //< Would be static if that did not prevent adding the tiles in the editor 
+    public static List<Tile> startTiles;
+    public static List<Tile> endTiles;
 
     //# Private Variables 
     private Vector2Int nodeGridSize;  //< Number of tiles in x/z axis
@@ -100,23 +102,39 @@ public class NodeManager : MonoBehaviour
     private void FetchAllTilesFromResourcesFolder()
     {
         TileDefinition[] allTileDefinitions = Resources.LoadAll<TileDefinition>("Tiles");
-        if (allTileDefinitions.Length == 0)
+        if (allTileDefinitions.Length == 0) //< Skip constructing tiles if no tile definitions could be located.
             return;
 
         allTiles = new List<Tile>();
+        startTiles = new List<Tile>();
+        endTiles = new List<Tile>();
         foreach (TileDefinition definition in allTileDefinitions)
         {
-            allTiles.Add(new Tile(definition));
+            List<Tile> listToAddTo;
+            switch (definition.optionalTileTag)
+            {
+                case TileTag.StartTile:
+                    listToAddTo = startTiles;
+                    break;
+                case TileTag.EndTile:
+                    listToAddTo = endTiles;
+                    break;
+                default:
+                    listToAddTo = allTiles;
+                    break;
+            }
+
+            listToAddTo.Add(new Tile(definition));
             if (!definition.generateRotatedVariants)
                 continue;
 
-            allTiles.Add(new Tile(TileDefinition.CreateRotatedVariant(definition, 1), 1));
+            listToAddTo.Add(new Tile(TileDefinition.CreateRotatedVariant(definition, 1), 1));
             if (definition.isMirrorable)
                 continue;
 
             for (int i = 2; i <= 3; i++)
             {
-                allTiles.Add(new Tile(TileDefinition.CreateRotatedVariant(definition, i), i));
+                listToAddTo.Add(new Tile(TileDefinition.CreateRotatedVariant(definition, i), i));
             }
         }
     }

--- a/Assets/PTD/Scripts/WaveFunctionCollapse/Tile.cs
+++ b/Assets/PTD/Scripts/WaveFunctionCollapse/Tile.cs
@@ -7,6 +7,7 @@ using System;
 public class Tile
 {
     public string name;
+    public TileTag tag;
     public GameObject prefab;
     public List<Socket> northSockets;
     public List<Socket> eastSockets;
@@ -28,10 +29,11 @@ public class Tile
     private GameObject instantiatedPrefab;
 
     /// <summary>
-    /// Create Tile from TileDefinition.
+    /// Construct Tile from TileDefinition.
     /// </summary>
     public Tile(TileDefinition definition, int rotationIterations = 0)
     {
+        this.tag = definition.optionalTileTag;
         this.prefab = definition.prefab;
         this.northSockets = new List<Socket>(definition.northSockets);
         this.eastSockets = new List<Socket>(definition.eastSockets);
@@ -43,10 +45,11 @@ public class Tile
     }
 
     /// <summary>
-    /// Create Tile from scratch.
+    /// Construct Tile from scratch.
     /// </summary>
-    public Tile(GameObject prefab, List<Socket> northSockets, List<Socket> eastSockets, List<Socket> southSockets, List<Socket> westSockets, int amountRotatedClockwise = 0)
+    public Tile(GameObject prefab, List<Socket> northSockets, List<Socket> eastSockets, List<Socket> southSockets, List<Socket> westSockets, TileTag tileTag = TileTag.None, int amountRotatedClockwise = 0)
     {
+        this.tag = tileTag;
         this.prefab = prefab;
         this.northSockets = new List<Socket>(northSockets);
         this.eastSockets = new List<Socket>(eastSockets);

--- a/Assets/PTD/Scripts/WaveFunctionCollapse/TileDefinition.cs
+++ b/Assets/PTD/Scripts/WaveFunctionCollapse/TileDefinition.cs
@@ -11,6 +11,8 @@ using UnityEngine;
 
 public enum Socket { h1, h1_2, h2, h2_3, h3, h3_4, h4, p2, p2_3, p3 }
 
+public enum TileTag { None, StartTile, EndTile }
+
 [ExecuteInEditMode]
 [CreateAssetMenu(fileName = "TileDefinition", menuName = "Wave Function Collapse/TileDefinition")]
 public class TileDefinition : ScriptableObject
@@ -25,6 +27,7 @@ public class TileDefinition : ScriptableObject
     public List<Socket> eastSockets;
     public List<Socket> southSockets;
     public List<Socket> westSockets;
+    public TileTag optionalTileTag;
 
     [Header("In-Editor Socket Bulk-Setup"), Space(10)]
     [SerializeField] private List<Socket> addToAllSides;
@@ -49,7 +52,7 @@ public class TileDefinition : ScriptableObject
             outputDefinition.southSockets = new List<Socket>(outputDefinition.eastSockets);
             outputDefinition.eastSockets = new List<Socket>(buffer);
         }
-        
+
         return outputDefinition;
     }
 


### PR DESCRIPTION
- With this system, you can easily define start and end tiles, which are then only generated at the respective path-start and -end nodes.
- See [d559d5c293b092118c571ef8657a4521514d6076] for more in-depth documentation